### PR TITLE
Add test coverage for Terraform outputs

### DIFF
--- a/test/integration/default/controls/index.rb
+++ b/test/integration/default/controls/index.rb
@@ -14,6 +14,11 @@
 
 project_id = attribute("project_id", default: ENV["TF_VAR_project"])
 
+describe terraform_outputs(dir: File.expand_path("../../../fixtures", File.dirname(__FILE__))) do
+  it { should exist }
+  its('project_id') { should eq project_id }
+end
+
 # Ensure first index is type 'Task'
 describe command("gcloud --project='#{project_id}' beta datastore indexes list --filter='properties[0].name=done' --format=json --quiet | jq -jce '.[0].kind'") do
   its('exit_status') { should eq 0 }

--- a/test/integration/default/controls/index.rb
+++ b/test/integration/default/controls/index.rb
@@ -21,19 +21,19 @@ describe command("gcloud --project='#{project_id}' beta datastore indexes list -
 end
 
 # Ensure first index has expected properties
-describe command("gcloud --project='#{PROJECT_ID}' beta datastore indexes list --filter='properties[0].name=done' --format=json --quiet | jq -jce '.[0].properties'") do
+describe command("gcloud --project='#{project_id}' beta datastore indexes list --filter='properties[0].name=done' --format=json --quiet | jq -jce '.[0].properties'") do
   its('exit_status') { should eq 0 }
   its('stdout') { should eq '[{"direction":"ASCENDING","name":"done"},{"direction":"DESCENDING","name":"priority"}]' }
 end
 
 # Ensure second index is type 'Task'
-describe command("gcloud --project='#{PROJECT_ID}' beta datastore indexes list --filter='properties[0].name=collaborators' --format=json --quiet | jq -jce '.[0].kind'") do
+describe command("gcloud --project='#{project_id}' beta datastore indexes list --filter='properties[0].name=collaborators' --format=json --quiet | jq -jce '.[0].kind'") do
   its('exit_status') { should eq 0 }
   its('stdout') { should eq 'Task' }
 end
 
 # Ensure second index has expected properties
-describe command("gcloud --project='#{PROJECT_ID}' beta datastore indexes list --filter='properties[0].name=collaborators' --format=json --quiet | jq -jce '.[0].properties'") do
+describe command("gcloud --project='#{project_id}' beta datastore indexes list --filter='properties[0].name=collaborators' --format=json --quiet | jq -jce '.[0].properties'") do
   its('exit_status') { should eq 0 }
   its('stdout') { should eq '[{"direction":"ASCENDING","name":"collaborators"},{"direction":"DESCENDING","name":"created"}]' }
 end

--- a/test/integration/default/inspec.yml
+++ b/test/integration/default/inspec.yml
@@ -1,0 +1,7 @@
+name: cloud-datastore
+title: Google Cloud Datastore
+version: 0.1.0
+inspec_version: '>= 2.2.10'
+depends:
+  - name: inspec-terraform
+    git: https://github.com/lagrange-automation/inspec-terraform


### PR DESCRIPTION
This pull request adds the `terraform_outputs` InSpec profile and adds test coverage to the module outputs.

This pull request also fixes up a small refactoring error in the InSpec tests.