### PR TITLE
Update indexes when index definitions change

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -20,14 +20,14 @@ driver:
 provisioner:
   name: "terraform"
 
-transport:
-  name: exec
-
 platforms:
   - name: local
 
 verifier:
-  name: inspec
+  name: terraform
+  systems:
+    - name: system
+      backend: local
 
 suites:
   - name: "default"

--- a/main.tf
+++ b/main.tf
@@ -24,31 +24,17 @@ resource "local_file" "cloud-datastore-index-file" {
   filename = "${local.path_file}"
 }
 
-resource "null_resource" "gcloud-activate-service-account" {
-  triggers {
-    changes_in_index_file = "${sha1(local_file.cloud-datastore-index-file.content)}"
-  }
-
-  provisioner "local-exec" {
-    command = "gcloud auth activate-service-account --key-file=${var.credentials}"
-  }
-}
-
 resource "null_resource" "cloud-datastore-indices" {
   triggers {
     changes_in_index_file = "${sha1(local_file.cloud-datastore-index-file.content)}"
   }
 
   provisioner "local-exec" {
-    command = "gcloud datastore indexes cleanup ${local_file.cloud-datastore-index-file.filename} --project=${var.project}"
+    command = "${path.module}/scripts/create-indexes.sh '${var.credentials}' '${var.project}' '${local_file.cloud-datastore-index-file.filename}'"
   }
 
   provisioner "local-exec" {
-    command = "gcloud datastore indexes create ${local_file.cloud-datastore-index-file.filename} --project=${var.project}"
-  }
-
-  provisioner "local-exec" {
-    command = "gcloud datastore indexes cleanup ${local.null_index_path_file} --project=${var.project}"
+    command = "${path.module}/scripts/destroy-indexes.sh '${var.credentials}' '${var.project}' '${local.null_index_path_file}'"
     when    = "destroy"
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -40,15 +40,15 @@ resource "null_resource" "cloud-datastore-indices" {
   }
 
   provisioner "local-exec" {
-    command = "gcloud datastore cleanup-indexes ${local_file.cloud-datastore-index-file.filename} --project=${var.project}"
+    command = "gcloud datastore indexes cleanup ${local_file.cloud-datastore-index-file.filename} --project=${var.project}"
   }
 
   provisioner "local-exec" {
-    command = "gcloud datastore create-indexes ${local_file.cloud-datastore-index-file.filename} --project=${var.project}"
+    command = "gcloud datastore indexes create ${local_file.cloud-datastore-index-file.filename} --project=${var.project}"
   }
 
   provisioner "local-exec" {
-    command = "gcloud datastore cleanup-indexes ${local.null_index_path_file} --project=${var.project}"
+    command = "gcloud datastore indexes cleanup ${local.null_index_path_file} --project=${var.project}"
     when    = "destroy"
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -36,7 +36,7 @@ resource "null_resource" "gcloud-activate-service-account" {
 
 resource "null_resource" "cloud-datastore-indices" {
   triggers {
-    changes_in_index_file = "${sha1(local_file.cloud-datastore-index-file.filename)}"
+    changes_in_index_file = "${sha1(local_file.cloud-datastore-index-file.content)}"
   }
 
   provisioner "local-exec" {

--- a/scripts/create-indexes.sh
+++ b/scripts/create-indexes.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+if [[ $# -lt 3 ]]; then
+  echo "usage: create-indexes.sh <credentials> <project> <indexes_file>" 1>&2
+  exit 1
+fi
+
+CREDENTIALS=$1
+PROJECT=$2
+INDEXES_FILE=$3
+
+export CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE="$CREDENTIALS"
+
+gcloud datastore indexes cleanup "$INDEXES_FILE" --project="$PROJECT" --quiet
+gcloud datastore indexes create "$INDEXES_FILE" --project="$PROJECT" --quiet

--- a/scripts/destroy-indexes.sh
+++ b/scripts/destroy-indexes.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+if [[ $# -lt 3 ]]; then
+  echo "usage: destroy-indexes.sh <credentials> <project> <indexes_file>" 1>&2
+  exit 1
+fi
+
+CREDENTIALS=$1
+PROJECT=$2
+INDEXES_FILE=$3
+
+export CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE="$CREDENTIALS"
+
+gcloud datastore indexes cleanup "$INDEXES_FILE" --project="$PROJECT" --quiet

--- a/test/integration/default/controls/index.rb
+++ b/test/integration/default/controls/index.rb
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+ENV['CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE'] = ENV['TF_VAR_credentials_file_path']
 project_id = attribute("project_id", default: ENV["TF_VAR_project"])
 
 describe terraform_outputs(dir: File.expand_path("../../../fixtures", File.dirname(__FILE__))) do

--- a/test/integration/default/controls/index.rb
+++ b/test/integration/default/controls/index.rb
@@ -22,23 +22,27 @@ end
 # Ensure first index is type 'Task'
 describe command("gcloud --project='#{project_id}' datastore indexes list --filter='properties[0].name=done' --format=json --quiet | jq -jce '.[0].kind'") do
   its('exit_status') { should eq 0 }
+  its('stderr') { should eq '' }
   its('stdout') { should eq 'Task' }
 end
 
 # Ensure first index has expected properties
 describe command("gcloud --project='#{project_id}' datastore indexes list --filter='properties[0].name=done' --format=json --quiet | jq -jce '.[0].properties'") do
   its('exit_status') { should eq 0 }
+  its('stderr') { should eq '' }
   its('stdout') { should eq '[{"direction":"ASCENDING","name":"done"},{"direction":"DESCENDING","name":"priority"}]' }
 end
 
 # Ensure second index is type 'Task'
 describe command("gcloud --project='#{project_id}' datastore indexes list --filter='properties[0].name=collaborators' --format=json --quiet | jq -jce '.[0].kind'") do
   its('exit_status') { should eq 0 }
+  its('stderr') { should eq '' }
   its('stdout') { should eq 'Task' }
 end
 
 # Ensure second index has expected properties
 describe command("gcloud --project='#{project_id}' datastore indexes list --filter='properties[0].name=collaborators' --format=json --quiet | jq -jce '.[0].properties'") do
   its('exit_status') { should eq 0 }
+  its('stderr') { should eq '' }
   its('stdout') { should eq '[{"direction":"ASCENDING","name":"collaborators"},{"direction":"DESCENDING","name":"created"}]' }
 end

--- a/test/integration/default/controls/index.rb
+++ b/test/integration/default/controls/index.rb
@@ -20,25 +20,25 @@ describe terraform_outputs(dir: File.expand_path("../../../fixtures", File.dirna
 end
 
 # Ensure first index is type 'Task'
-describe command("gcloud --project='#{project_id}' beta datastore indexes list --filter='properties[0].name=done' --format=json --quiet | jq -jce '.[0].kind'") do
+describe command("gcloud --project='#{project_id}' datastore indexes list --filter='properties[0].name=done' --format=json --quiet | jq -jce '.[0].kind'") do
   its('exit_status') { should eq 0 }
   its('stdout') { should eq 'Task' }
 end
 
 # Ensure first index has expected properties
-describe command("gcloud --project='#{project_id}' beta datastore indexes list --filter='properties[0].name=done' --format=json --quiet | jq -jce '.[0].properties'") do
+describe command("gcloud --project='#{project_id}' datastore indexes list --filter='properties[0].name=done' --format=json --quiet | jq -jce '.[0].properties'") do
   its('exit_status') { should eq 0 }
   its('stdout') { should eq '[{"direction":"ASCENDING","name":"done"},{"direction":"DESCENDING","name":"priority"}]' }
 end
 
 # Ensure second index is type 'Task'
-describe command("gcloud --project='#{project_id}' beta datastore indexes list --filter='properties[0].name=collaborators' --format=json --quiet | jq -jce '.[0].kind'") do
+describe command("gcloud --project='#{project_id}' datastore indexes list --filter='properties[0].name=collaborators' --format=json --quiet | jq -jce '.[0].kind'") do
   its('exit_status') { should eq 0 }
   its('stdout') { should eq 'Task' }
 end
 
 # Ensure second index has expected properties
-describe command("gcloud --project='#{project_id}' beta datastore indexes list --filter='properties[0].name=collaborators' --format=json --quiet | jq -jce '.[0].properties'") do
+describe command("gcloud --project='#{project_id}' datastore indexes list --filter='properties[0].name=collaborators' --format=json --quiet | jq -jce '.[0].properties'") do
   its('exit_status') { should eq 0 }
   its('stdout') { should eq '[{"direction":"ASCENDING","name":"collaborators"},{"direction":"DESCENDING","name":"created"}]' }
 end

--- a/test/integration/default/controls/index.rb
+++ b/test/integration/default/controls/index.rb
@@ -15,11 +15,6 @@
 ENV['CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE'] = ENV['TF_VAR_credentials_file_path']
 project_id = attribute("project_id", default: ENV["TF_VAR_project"])
 
-describe terraform_outputs(dir: File.expand_path("../../../fixtures", File.dirname(__FILE__))) do
-  it { should exist }
-  its('project_id') { should eq project_id }
-end
-
 # Ensure first index is type 'Task'
 describe command("gcloud --project='#{project_id}' datastore indexes list --filter='properties[0].name=done' --format=json --quiet | jq -jce '.[0].kind'") do
   its('exit_status') { should eq 0 }

--- a/test/integration/default/inspec.yml
+++ b/test/integration/default/inspec.yml
@@ -2,6 +2,3 @@ name: cloud-datastore
 title: Google Cloud Datastore
 version: 0.1.0
 inspec_version: '>= 2.2.10'
-depends:
-  - name: inspec-terraform
-    git: https://github.com/lagrange-automation/inspec-terraform


### PR DESCRIPTION
The null_resource creating and cleaning up indexes was triggering when
the filename changed, but the filename in question was a temporary file
whose name wouldn't change with the content. This commit changes the
triggering to occur when the index content changes.

This pull request is based on #5. If needed it can be refactored to be an independent pull request, otherwise it should be merged after #5 is merged.