### PR TITLE
[docs] Change source reference in README to reflect registry source address

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Currently, it supports **index creation** by shelling out to gcloud.
 
 ```
 module "datastore" {
-  source      = "../"
+  source      = "terraform-google-modules/cloud-datastore/google"
   credentials = "sa-key.json"
   project     = "my-project-id"
   indexes     = "${file("index.yaml")}"


### PR DESCRIPTION
This PR changes the github source referenced in the README example docs to a standard registry source address to reference the published registry module.